### PR TITLE
ensure engine generates SQL in WASM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,6 +150,12 @@ source = "git+https://github.com/prisma/barrel.git?branch=mssql-support#4e84cf3d
 
 [[package]]
 name = "base64"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2015e3793554aa5b6007e3a72959e84c1070039e74f13dde08fa64afe1ddd892"
+
+[[package]]
+name = "base64"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
@@ -435,6 +441,8 @@ checksum = "510ca239cf13b7f8d16a2b48f263de7b4f8c566f0af58d901031473c76afb1e3"
 name = "connector-wasm"
 version = "0.1.0"
 dependencies = [
+ "base64 0.2.1",
+ "getrandom 0.2.7",
  "psl",
  "query-core",
  "request-handlers",
@@ -442,6 +450,7 @@ dependencies = [
  "sql-query-connector",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-bindgen-test",
 ]
 
 [[package]]
@@ -455,6 +464,16 @@ dependencies = [
  "libc",
  "terminal_size",
  "winapi",
+]
+
+[[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1059,8 +1078,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1318,6 +1339,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -2616,6 +2640,7 @@ dependencies = [
  "enumflags2",
  "futures",
  "indexmap",
+ "instant",
  "itertools",
  "lru",
  "once_cell",
@@ -2634,6 +2659,7 @@ dependencies = [
  "tracing-subscriber",
  "user-facing-errors",
  "uuid 1.1.2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3249,6 +3275,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3619,6 +3651,7 @@ dependencies = [
  "tracing-opentelemetry",
  "user-facing-errors",
  "uuid 1.1.2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4608,6 +4641,30 @@ name = "wasm-bindgen-shared"
 version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45c8d417d87eefa0087e62e3c75ad086be39433449e2961add9a5d9ce5acc2f1"
+dependencies = [
+ "console_error_panic_hook",
+ "js-sys",
+ "scoped-tls",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0e560d44db5e73b69a9757a15512fe7e1ef93ed2061c928871a4025798293dd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "wasm-logger"

--- a/quaint/src/connector/connection_info.rs
+++ b/quaint/src/connector/connection_info.rs
@@ -120,7 +120,7 @@ impl ConnectionInfo {
     pub fn schema_name(&self) -> &str {
         match self {
             #[cfg(feature = "postgresql")]
-            ConnectionInfo::Postgres(url) => todo!(),
+            ConnectionInfo::Postgres(url) => "no_schema",
             #[cfg(feature = "mysql")]
             ConnectionInfo::Mysql(url) => url.dbname(),
             #[cfg(feature = "mssql")]

--- a/query-engine/connector-wasm/Cargo.toml
+++ b/query-engine/connector-wasm/Cargo.toml
@@ -5,11 +5,19 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 wasm-bindgen = "0.2"
-wasm-bindgen-futures = "*"
+wasm-bindgen-futures = "0.4"
 sql-query-connector = { path = "../connectors/sql-query-connector" }
 schema = { path = "../schema" }
 psl.workspace = true
 request-handlers = { path = "../request-handlers" }
 query-core = { path = "../core" }
+getrandom = { version = "0.2", features = ["js"] }
+base64 = "0.2"
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3.0"

--- a/query-engine/connectors/sql-query-connector/Cargo.toml
+++ b/query-engine/connectors/sql-query-connector/Cargo.toml
@@ -25,6 +25,7 @@ uuid.workspace = true
 opentelemetry = { version = "0.17", features = ["tokio"] }
 tracing-opentelemetry = "0.17.3"
 quaint.workspace = true
+wasm-bindgen = "0.2"
 
 [dependencies.connector-interface]
 package = "query-connector"

--- a/query-engine/connectors/sql-query-connector/src/context.rs
+++ b/query-engine/connectors/sql-query-connector/src/context.rs
@@ -13,20 +13,19 @@ pub(super) struct Context<'a> {
 
 impl<'a> Context<'a> {
     pub(crate) fn new(connection_info: &'a ConnectionInfo, trace_id: Option<&'a str>) -> Self {
-        todo!()
-        // let (max_rows, default_batch_size) = match connection_info {
-        //     ConnectionInfo::Postgres(_) => (None, 32766),
-        //     // See https://stackoverflow.com/a/11131824/788562
-        //     ConnectionInfo::Mysql(_) => (None, 65535),
-        //     ConnectionInfo::Mssql(_) => (Some(1000), 2099),
-        //     ConnectionInfo::Sqlite { .. } | ConnectionInfo::InMemorySqlite { .. } => (Some(999), 999),
-        // };
-        // Context {
-        //     connection_info,
-        //     trace_id,
-        //     max_rows,
-        //     max_bind_values: get_batch_size(default_batch_size),
-        // }
+        let (max_rows, default_batch_size) = match connection_info {
+            ConnectionInfo::Postgres(_) => (None, 32766),
+            // See https://stackoverflow.com/a/11131824/788562
+            // ConnectionInfo::Mysql(_) => (None, 65535),
+            // ConnectionInfo::Mssql(_) => (Some(1000), 2099),
+            // ConnectionInfo::Sqlite { .. } | ConnectionInfo::InMemorySqlite { .. } => (Some(999), 999),
+        };
+        Context {
+            connection_info,
+            trace_id,
+            max_rows,
+            max_bind_values: get_batch_size(default_batch_size),
+        }
     }
 
     pub(crate) fn schema_name(&self) -> &str {

--- a/query-engine/connectors/sql-query-connector/src/database/postgresql.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/postgresql.rs
@@ -29,20 +29,22 @@ use quaint::prelude::Query;
 use quaint::prelude::ResultSet;
 use quaint::visitor::Visitor;
 
-use tracing::info;
+macro_rules! console_log {
+    ($($t:tt)*) => (crate::log(&format_args!($($t)*).to_string()))
+}
 
 #[async_trait::async_trait]
 impl Queryable for ConsoleQueryable {
     /// Execute the given query.
     async fn query(&self, q: Query<'_>) -> quaint::Result<ResultSet> {
         let (sql, params) = quaint::visitor::Postgres::build(q)?;
-        info!("{}", sql);
+        console_log!("{}", sql);
         Ok(ResultSet::new(vec![], vec![]))
     }
 
     /// Execute a query given as SQL, interpolating the given parameters.
     async fn query_raw(&self, sql: &str, params: &[Value<'_>]) -> quaint::Result<ResultSet> {
-        info!("{}", sql);
+        console_log!("{}", sql);
         Ok(ResultSet::new(vec![], vec![]))
     }
 
@@ -53,21 +55,21 @@ impl Queryable for ConsoleQueryable {
     ///
     /// NOTE: This method will eventually be removed & merged into Queryable::query_raw().
     async fn query_raw_typed(&self, sql: &str, params: &[Value<'_>]) -> quaint::Result<ResultSet> {
-        info!("{}", sql);
+        console_log!("{}", sql);
         Ok(ResultSet::new(vec![], vec![]))
     }
 
     /// Execute the given query, returning the number of affected rows.
     async fn execute(&self, q: Query<'_>) -> quaint::Result<u64> {
         let (sql, params) = quaint::visitor::Postgres::build(q)?;
-        info!("{}", sql);
+        console_log!("{}", sql);
         Ok(0)
     }
 
     /// Execute a query given as SQL, interpolating the given parameters and
     /// returning the number of affected rows.
     async fn execute_raw(&self, sql: &str, params: &[Value<'_>]) -> quaint::Result<u64> {
-        info!("{}", sql);
+        console_log!("{}", sql);
         Ok(0)
     }
 
@@ -79,14 +81,14 @@ impl Queryable for ConsoleQueryable {
     ///
     /// NOTE: This method will eventually be removed & merged into Queryable::query_raw().
     async fn execute_raw_typed(&self, sql: &str, params: &[Value<'_>]) -> quaint::Result<u64> {
-        info!("{}", sql);
+        console_log!("{}", sql);
         Ok(0)
     }
 
     /// Run a command in the database, for queries that can't be run using
     /// prepared statements.
     async fn raw_cmd(&self, cmd: &str) -> quaint::Result<()> {
-        info!("{}", cmd);
+        console_log!("{}", cmd);
         Ok(())
     }
 

--- a/query-engine/connectors/sql-query-connector/src/lib.rs
+++ b/query-engine/connectors/sql-query-connector/src/lib.rs
@@ -28,3 +28,14 @@ pub use database::js::register_driver;
 pub use error::SqlError;
 
 type Result<T> = std::result::Result<T, error::SqlError>;
+
+use wasm_bindgen::prelude::*;
+
+// lifted from the `console_log` example
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_namespace = console)]
+    pub fn log(a: &str);
+}
+
+

--- a/query-engine/core/Cargo.toml
+++ b/query-engine/core/Cargo.toml
@@ -30,3 +30,5 @@ uuid = "1"
 schema = { path = "../schema" }
 lru = "0.7.7"
 enumflags2 = "0.7"
+instant = { version = "0.1", features = [ "wasm-bindgen", "inaccurate" ] }
+wasm-bindgen = "0.2"

--- a/query-engine/core/src/executor/execute_operation.rs
+++ b/query-engine/core/src/executor/execute_operation.rs
@@ -6,7 +6,8 @@ use crate::{
 use connector::{Connection, ConnectionLike, Connector};
 use futures::future;
 use schema::{QuerySchema, QuerySchemaRef};
-use std::time::{Duration, Instant};
+use std::time::{Duration};
+use instant::Instant;
 use tracing::Instrument;
 use tracing_futures::WithSubscriber;
 

--- a/query-engine/core/src/executor/pipeline.rs
+++ b/query-engine/core/src/executor/pipeline.rs
@@ -1,4 +1,5 @@
 use crate::{Env, Expressionista, IrSerializer, QueryGraph, QueryInterpreter, ResponseData};
+use prisma_models::PrismaValue;
 use schema::QuerySchema;
 use tracing::Instrument;
 
@@ -39,6 +40,8 @@ impl<'conn, 'schema> QueryPipeline<'conn, 'schema> {
             .await;
 
         trace!("{}", self.interpreter.log_output());
-        serializer.serialize(result?, query_schema)
+        use crate::response_ir::Item;
+        Ok(ResponseData::new("empty".to_string(), Item::Value(PrismaValue::Null)))
+        // serializer.serialize(result?, query_schema) // TODO: serialize
     }
 }

--- a/query-engine/core/src/response_ir/internal.rs
+++ b/query-engine/core/src/response_ir/internal.rs
@@ -23,6 +23,20 @@ type CheckedItemsWithParents = IndexMap<Option<SelectionResult>, Item>;
 /// the contained items, i.e. the Items are all unchecked.
 type UncheckedItemsWithParents = IndexMap<Option<SelectionResult>, Vec<Item>>;
 
+use wasm_bindgen::prelude::*;
+
+// lifted from the `console_log` example
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_namespace = console)]
+    fn log(a: &str);
+}
+
+macro_rules! console_log {
+    ($($t:tt)*) => (log(&format_args!($($t)*).to_string()))
+}
+
+
 /// The query validation makes sure that the output selection already has the correct shape.
 /// This means that we can make the following assumptions:
 /// - Objects don't need to check required fields.

--- a/query-engine/request-handlers/Cargo.toml
+++ b/query-engine/request-handlers/Cargo.toml
@@ -13,7 +13,7 @@ itertools = "0.10"
 graphql-parser = { git = "https://github.com/prisma/graphql-parser" }
 serde.workspace = true
 serde_json.workspace = true
-futures = { version = "0.3", no-default-features = true }
+futures = "0.3"
 indexmap = { version = "1.7", features = ["serde-1"] }
 bigdecimal = "0.3"
 thiserror = "1"


### PR DESCRIPTION
With this PR, SQLs can be generated from the request of the Prisma client side. A unit test is added with the example request + schema.